### PR TITLE
Select available and active charging behaviour.

### DIFF
--- a/src/battery_handling.rs
+++ b/src/battery_handling.rs
@@ -120,8 +120,18 @@ impl BatteryState {
     }
 
     fn refresh_charge_behaviour(&mut self) -> Result<(), BatteryError> {
-        let behaviour_str =
+        let all =
             fs::read_to_string(CHARGE_BEHAVIOUR_FILE_PATH).or(Err(BatteryError::NotAccessible))?;
+
+        // select active and available charging behaviour
+        let behaviour_str = if let Some(index_open) = all.find('[') {
+            let index_close = all[index_open + 1..]
+                .find(']')
+                .ok_or(BatteryError::UnexpectedValue)?;
+            all[index_open + 1..index_open + 1 + index_close].to_string()
+        } else {
+            all
+        };
 
         self.charge_behaviour = match behaviour_str.trim() {
             "auto" => ChargeBehaviour::Auto,


### PR DESCRIPTION
The method to parse `charge_behaviour` seems to be outdated:
``` console
# cat /sys/class/power_supply/macsmc-battery/charge_behaviour
auto [inhibit-charge] force-discharge
# asahi-battery-threshold
[2024-08-22T13:27:27Z INFO  asahi_battery_threshold] Initializing
[2024-08-22T13:27:27Z INFO  asahi_battery_threshold] Loaded config file
Error:
   0: unexpected value found in sys file, this is a bug

Location:
   src/main.rs:29

Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
```

(Rust's backtrace provided no additional information to locate the bug—not even the source file that returned the error!)

It seems that `BatteryState::refresh_charge_behaviour` expects the content of the file to be **any one** of the available behaviour strings. However, **all the available behaviour strings** are shown (and separated by spaces) now by `sysfs`, with the **active one surrounded by brackets**. This commit ensures that `behaviour_str` is equal to the **active** behaviour string.

This commit for `charge_behaviour sysfs` supports the reported behaviour: https://github.com/AsahiLinux/linux/commit/539b9c94ac83563842a27e8cc3de5164b15c4de0#diff-26a34bdf517a2c3615852fd28ed9a693536b2910dffe25884e6d76e33ceb5616R503-R515.